### PR TITLE
Fix for Issue 12

### DIFF
--- a/test/car_dataset_tests/test_dataset.py
+++ b/test/car_dataset_tests/test_dataset.py
@@ -155,3 +155,58 @@ def test_cardataset_get_item_value_images(temp_dir,loaded_dataset,index,outcome)
     image_expected = Image.open(os.path.join(temp_dir,outcome))
 
     assert image_retr == image_expected, ("Images Are Not the same!!")
+
+def test_nan_removal(loaded_dataset):
+    cur_length = len(loaded_dataset)
+    loaded_dataset.drop_nan()
+    new_length = len(loaded_dataset)
+    assert new_length == 2054, ("Original Length = {}\nNew Length = "
+        "{}\nExpected New Length = 2054".format(cur_length,new_length))
+
+@pytest.mark.parametrize(
+        "index,outcome",[
+        (0,True),
+        (1199,True),
+        (1200,True),
+        (1201,True),
+        (2053,True),
+        (2054,False),
+        (2399,False),
+        (2400,False),
+        (-1,False)])
+def test_after_nan_cardataset_get_item_index(loaded_dataset,index,outcome):
+    try:
+        item = loaded_dataset[index]
+    except DatasetError as e:
+        assert not outcome, "Got Error {}".format(e.message)
+
+@pytest.mark.parametrize(
+        "index,outcome",[
+        (0,[3.346066188150387949e-02, 3.149205029088487234e-02]),
+        (1199,[3.376331391075349658e-02, 3.256499232905601254e-02]),
+        (1200,[2.162449375247458075e-02, 2.197126520637055977e-02]),
+        (1201,[2.167494525873153027e-02, 2.196024970631171858e-02]),
+        (2053,[2.761138162404873017e-02, 2.093151905506832750e-02])])
+def test_after_nan_cardataset_get_item_value_angles(loaded_dataset,index,outcome):
+    item = loaded_dataset[index]
+    angles = item['angles']
+
+    pitch_retr = round(angles[0].item(),4)
+    pitch_expected = round(outcome[0],4)
+    assert pitch_retr == pitch_expected, ("Pitch Mismatch, Expected "
+        "{}, Got {}".format(pitch_expected,pitch_retr))
+
+@pytest.mark.parametrize(
+        "index,outcome",[
+        (0,os.path.join("0_Frames","0_0001.jpg")),
+        (1199,os.path.join("0_Frames","0_1200.jpg")),
+        (1200,os.path.join("3_Frames","3_0001.jpg")),
+        (1201,os.path.join("3_Frames","3_0002.jpg")),
+        (2053,os.path.join("3_Frames","3_1200.jpg"))])
+def test_after_nan_cardataset_get_item_value_images(temp_dir,loaded_dataset,index,outcome):
+    item = loaded_dataset[index]
+    image_retr = item['image']
+    print(os.listdir())
+    image_expected = Image.open(os.path.join(temp_dir,outcome))
+
+    assert image_retr == image_expected, ("Images Are Not the same!!")

--- a/util/car_dataset.py
+++ b/util/car_dataset.py
@@ -59,6 +59,10 @@ class CarDataset(torch.utils.data.Dataset):
             # If File Exists, Read into self.label_frames
             working_frame = pd.read_csv(label_file,sep=' ',names=['pitch','yaw'])
             #TODO: Dealing with NaN should happen around here
+            '''
+            Can't just drop NaN from the dataframe without reconciling
+            the image list.
+            '''
             self.label_frames.append(working_frame)
 
         # Run Validate To Catch any Error
@@ -118,6 +122,13 @@ class CarDataset(torch.utils.data.Dataset):
 
         raise DatasetError(("Index {} Out of Bounds in dataset of size"
                 " {}").format(idx,len(self)))
+
+    def drop_nan(self):
+        '''
+        Labelframes may contain NaN values. Rows with NaN should be
+        dropped. Corresponding images should also be discarded.
+        '''
+        pass
 
 class DatasetError(Exception):
     def __init__(self,message="Problem loading data!"):

--- a/util/car_dataset.py
+++ b/util/car_dataset.py
@@ -6,6 +6,7 @@ import sys
 import os
 import torch
 import pandas as pd
+import numpy as np
 from PIL import Image
 
 def check_dir(dir_path):
@@ -115,20 +116,49 @@ class CarDataset(torch.utils.data.Dataset):
             len_in_folder = len(self.image_locations[folder_idx])
             if idx < len_in_folder:
                 # Required Index is Here!
-                sub_idx = idx - offset
-                return (folder_idx,sub_idx)
+                return (folder_idx,idx)
             offset+=len_in_folder
             idx -= offset
 
         raise DatasetError(("Index {} Out of Bounds in dataset of size"
                 " {}").format(idx,len(self)))
 
+    def has_nan(self,item):
+        '''
+        Returns True if item has a NaN value in angles.
+        '''
+        return any(torch.isnan(item['angles']))
+
     def drop_nan(self):
         '''
         Labelframes may contain NaN values. Rows with NaN should be
         dropped. Corresponding images should also be discarded.
+
+        Loops through dataset and drops items in the image list and
+        corresponding dataframe.
         '''
-        pass
+        new_image_locations = list()
+        new_label_frames = list()
+        for df in self.label_frames:
+            new_label_frames.append(df.iloc[0:0,:].copy())
+            new_image_locations.append(list())
+
+        # Start Loop
+        for ind in range(len(self)):
+            if self.has_nan(self[ind]):
+                continue
+            else:
+                folder_idx, sub_idx = self.get_offset(ind)
+                # Copy to New image list
+                loc = (self.image_locations[folder_idx][sub_idx])
+                new_image_locations[folder_idx].append(loc)
+                # Copy to New Dataframe
+                val = self.label_frames[folder_idx].iloc[sub_idx]
+                new_df = new_label_frames[folder_idx].append(val)
+                new_label_frames[folder_idx] = new_df
+
+        self.image_locations = new_image_locations
+        self.label_frames = new_label_frames
 
 class DatasetError(Exception):
     def __init__(self,message="Problem loading data!"):


### PR DESCRIPTION
Resolves #12 

- Added a new function `drop_nan()` within the `CarDataset` class to check and drop items with NaN. This is an optional method a user can call after initializing the dataset.
- Added tests (modified copies of earlier tests) to verify that the dataset after dropping NaN items still map the correct images to angles.
- Also fixed a logical bug in `get_offset()`. The bug was causing negative indices to be returned for `sub_idx`. Was not causing issues when the datasets were whole but started throwing index errors while testing on dataset after dropping NaNs.
- All tests passing.
